### PR TITLE
docs: Update composer create-project commands to official package naming

### DIFF
--- a/content/en/docs/developer/getting-started/_index.md
+++ b/content/en/docs/developer/getting-started/_index.md
@@ -102,7 +102,7 @@ git checkout -b feature/my-contribution
 
 ```bash
 # 1. Create a new project
-composer create-project ymca/yusaopeny-project ymca-dev --no-interaction
+composer create-project ycloudyusa/yusaopeny-project ymca-dev --no-interaction
 cd ymca-dev
 ```
 

--- a/content/en/docs/development/Sandboxes/_index.md
+++ b/content/en/docs/development/Sandboxes/_index.md
@@ -46,7 +46,7 @@ These sandboxes are based on the latest [stable release](https://github.com/YClo
     <summary>These sandboxes are built on CI by running:</summary>
 
 ```sh
-composer create-project YCloudYUSA/yusaopeny-project buildnew --no-interaction --prefer-dist
+composer create-project ycloudyusa/yusaopeny-project buildnew --no-interaction
 
 ansible-playbook docroot/reinstall.yml -i /tmp/inventory5068801741271597001.ini -f 5 -e php_env_vars=APP_ENV=dev -e mysql_user=*** -e mysql_password=*** -e mysql_db=sandbox_carnation_custom -e drupal_folder=/var/www/sandbox_carnation_custom -e site_url=https://sandbox-carnation-cus.y.org -e pp_environment=demo -e run_reinstall=true -e "openy_profile_install_settings='openy_configure_profile.preset=complete openy_theme_select.theme=openy_carnation'" -e use_solr=false -i localhost, --connection=local -vvvv
 ```
@@ -65,7 +65,7 @@ These sandboxes are based on the [latest development version](https://github.com
     <summary>These sandboxes are built on CI by running:</summary>
 
 ```sh
-composer create-project YCloudYUSA/yusaopeny-project:dev-9.2.x-development buildnew --no-interaction --prefer-dist
+composer create-project ycloudyusa/yusaopeny-project:10.2.x-development-dev buildnew --no-interaction
 
 ansible-playbook docroot/reinstall.yml -i /tmp/inventory5068801741271597001.ini -f 5 -e php_env_vars=APP_ENV=dev -e mysql_user=*** -e mysql_password=*** -e mysql_db=sandbox_carnation_custom -e drupal_folder=/var/www/sandbox_carnation_custom -e site_url=https://sandbox-carnation-cus.y.org -e pp_environment=demo -e run_reinstall=true -e "openy_profile_install_settings='openy_configure_profile.preset=complete openy_theme_select.theme=openy_carnation'" -e use_solr=false -i localhost, --connection=local -vvvv
 ```
@@ -94,7 +94,7 @@ These are based on the YMCA Website Services stable Standard profile and the dev
     <summary>To rebuild the sandbox, CI is running:</summary>
 
 ```sh
-composer create-project YCloudYUSA/yusaopeny-project buildnew --no-interaction --prefer-dist
+composer create-project ycloudyusa/yusaopeny-project buildnew --no-interaction
 cd buildnew
 composer config minimum-stability dev
 composer require "openy/openy_memberships":"dev-master as 1.0.0"
@@ -113,9 +113,9 @@ ansible-playbook docroot/reinstall.yml -i /tmp/inventory13097841656330601319.ini
     <summary>To rebuild the sandbox, CI is running:</summary>
 
 ```sh
-composer create-project YCloudYUSA/yusaopeny-project:dev-9.2.x-development-af4 build --no-interaction --prefer-dist
+composer create-project ycloudyusa/yusaopeny-project:10.2.x-development-dev build --no-interaction
 cd ${WORKSPACE}/build
-composer require YCloudYUSA/yusaopeny_activity_finder:"4.x-dev as 4.0"
+composer require ycloudyusa/yusaopeny_activity_finder:"4.x-dev as 4.0"
 
 ansible-playbook docroot/reinstall.yml -i /tmp/inventory4660848605526222353.ini -f 5 -e php_env_vars=APP_ENV=dev -e mysql_user=*** -e mysql_password=*** -e mysql_db=d9_sandbox_carnation_custom -e drupal_folder=/var/www/d9_sandbox_carnation_custom -e site_url=https://sandbox-carnation-cus-d9.y.org -e pp_environment=demo -e run_reinstall=true -e "openy_profile_install_settings='openy_configure_profile.preset=complete openy_theme_select.theme=openy_carnation'" -i localhost, --connection=local -vvvv
 

--- a/content/en/docs/development/Testing-Open-Y-for-PHP-7.4-version-support/_index.md
+++ b/content/en/docs/development/Testing-Open-Y-for-PHP-7.4-version-support/_index.md
@@ -14,7 +14,7 @@ aliases:
 1. Obtain latest development code of YMCA Website Services
 
 ```sh
-composer create-project YCloudYUSA/yusaopeny-project:9.2.x-development-dev openy7.4
+composer create-project ycloudyusa/yusaopeny-project:10.2.x-development-dev openy7.4
 ```
 
 2. Add phpcompatibility to require-dev section

--- a/content/en/docs/development/program-event-framework/activity-finder/solr-configuration/_index.md
+++ b/content/en/docs/development/program-event-framework/activity-finder/solr-configuration/_index.md
@@ -2,13 +2,13 @@
 title: Configuring Solr for Activity Finder
 ---
 
-In order to install Open Y and Activity Finder v4 you need to run command
+In order to install YMCA Website Services and Activity Finder v4 you need to run command
 
 ```bash
-composer create-project ymcatwincities/openy-project build --no-interaction --prefer-dist
+composer create-project ycloudyusa/yusaopeny-project build --no-interaction
 ```
 
-Which will pull Open Y on Drupal stable version with Activity Finder v4 latest stable version
+Which will pull YMCA Website Services on Drupal stable version with Activity Finder v4 latest stable version
 Then you should proceed with a regular installation with Demo content enabled as described in our tutorials. It’s better to setup Extended or Custom( only via drush ) in order to skip a bunch of manual steps
 
 When you have YMCA Website Services (former Open Y) installed, list of the command you need to run in order to enable Activity Finder v4

--- a/content/en/docs/site-builder/getting-started/_index.md
+++ b/content/en/docs/site-builder/getting-started/_index.md
@@ -83,7 +83,7 @@ For detailed requirements, see [Server Requirements](/docs/development/server-re
 
 ```bash
 # 1. Create a new project
-composer create-project ymca/small-y-project MY_YMCA_SITE --no-interaction
+composer create-project ycloudyusa/yusaopeny-project MY_YMCA_SITE --no-interaction
 
 # 2. Navigate to the directory
 cd MY_YMCA_SITE
@@ -100,7 +100,7 @@ drush site:install openy_lily \
 
 ```bash
 # 1. Create a new project
-composer create-project ymca/yusaopeny-project MY_YMCA_SITE --no-interaction
+composer create-project ycloudyusa/yusaopeny-project MY_YMCA_SITE --no-interaction
 
 # 2. Navigate to the directory
 cd MY_YMCA_SITE


### PR DESCRIPTION
Updated all composer create-project references across documentation to use the official ycloudyusa/yusaopeny-project package name from the GitHub repository

Changes:

- Site Builder: ymca/small-y-project and ymca/yusaopeny-project to ycloudyusa/yusaopeny-project

- Developer Getting Started: ymca/yusaopeny-project to ycloudyusa/yusaopeny-project

- Activity Finder Solr: ymcatwincities/openy-project to ycloudyusa/yusaopeny-project

- Sandboxes: Normalized to ycloudyusa and updated versions 9.2.x to 10.2.x-development-dev

- Testing: Updated version to 10.2.x-development-dev