### PR TITLE
Update docs for YMCA Website Services 11.3.1.0 release

### DIFF
--- a/content/en/docs/content-structure/paragraphs/Group Schedules.md
+++ b/content/en/docs/content-structure/paragraphs/Group Schedules.md
@@ -1,8 +1,12 @@
 ---
-title: Group Schedules
+title: Group Schedules (Deprecated)
 ---
 
-This is dynamic paragraph that renders the group schedules from GroupEx Pro.
+{{% alert title="Deprecated" color="warning" %}}
+The GroupEx Pro API is no longer available. As of `groupexpro` 3.0.0, the deprecated modules (`groupex_form_cache`, `openy_group_schedules`, `openy_gxp`) are automatically uninstalled during `drush updb`. No manual action is needed.
+{{% /alert %}}
+
+This was a dynamic paragraph that rendered group schedules from GroupEx Pro.
 
 ### Fields
 

--- a/content/en/docs/content-structure/taxonomy/Media Tags.md
+++ b/content/en/docs/content-structure/taxonomy/Media Tags.md
@@ -2,6 +2,8 @@
 title: Media Tags
 ---
 
-This is a vocabulary that will be used for adding media tags that will allow you to structure your media assets library.
+This is a vocabulary used for adding media tags that allow you to structure your media assets library.
 
-**Machine name**: media_tags
+**Machine name**: `media_tags`
+
+As of version 11.3.1.0, **Media Tags** replaces the previous `media_directories` vocabulary. Media directories have been removed and migrated to Media Tags during the upgrade process.

--- a/content/en/docs/decision-maker/_index.md
+++ b/content/en/docs/decision-maker/_index.md
@@ -110,7 +110,7 @@ hide_sidebar: true
         <div class="text-muted" style="font-size: 0.95rem;">
           <strong>You'll learn:</strong>
           <ul class="mb-0 mt-2">
-            <li>Latest release (Drupal 11.1.x)</li>
+            <li>Latest release (Drupal 11.3.x)</li>
             <li>Recent feature additions</li>
             <li>Security updates</li>
             <li>Upgrade timeline</li>

--- a/content/en/docs/developer/getting-started/_index.md
+++ b/content/en/docs/developer/getting-started/_index.md
@@ -110,7 +110,7 @@ cd ymca-dev
 
 ```bash
 # 1. Configure DDEV
-ddev config --project-type=drupal10 --docroot=web --create-docroot
+ddev config --project-type=drupal --docroot=web --create-docroot
 
 # 2. Start DDEV
 ddev start

--- a/content/en/docs/development/Decoupled-(-external-)-projects-of-OpenY/_index.md
+++ b/content/en/docs/development/Decoupled-(-external-)-projects-of-OpenY/_index.md
@@ -14,16 +14,16 @@ Check all GitHub for the tag [``openy-decoupled``](https://github.com/topics/ope
 1. [`YCloudYUSA/yusaopeny_memberships`](https://github.com/YCloudYUSA/yusaopeny_memberships) - Membership Framework for OpenY and Drupal.
 1. [`YCloudYUSA/yusaopeny_prgf_sidebar_menu`](https://github.com/YCloudYUSA/yusaopeny_prgf_sidebar_menu) - SideBar menu for referencing menu blocks and using in SideBars across different pages.
 1. [`YCloudYUSA/yusaopeny_loc_finder`](https://github.com/YCloudYUSA/yusaopeny_loc_filter) - Extended Location Finder
-1. [`Open-Y-subprojects/reqclique_gxp_sync`](https://github.com/Open-Y-subprojects/reqclique_gxp_sync) - Reqclique Group Exercise Sync
+1. [`Open-Y-subprojects/reqclique_gxp_sync`](https://github.com/Open-Y-subprojects/reqclique_gxp_sync) - Reqclique Group Exercise Sync — **Deprecated.** GroupEx Pro API is no longer available.
 1. [`open-y-subprojects/virtual_y_signaling_server`](https://github.com/open-y-subprojects/virtual_y_signaling_server) - Signalling server for Virtual Y
-1. [`open-y-subprojects/openy_daxko_gxp_syncer`](https://github.com/open-y-subprojects/openy_daxko_gxp_syncer) - Daxko GroupEx PRO v1 API Syncer into Program Event Framework
-1. [`open-y-subprojects/ynorth_gxp_spots_proxy`](https://github.com/open-y-subprojects/ynorth_gxp_spots_proxy) - Availability Spots Cache Proxy for Groupex PRO embed API Syncer into PEF
+1. [`open-y-subprojects/openy_daxko_gxp_syncer`](https://github.com/open-y-subprojects/openy_daxko_gxp_syncer) - Daxko GroupEx PRO v1 API Syncer into Program Event Framework — **Deprecated.** GroupEx Pro API is no longer available.
+1. [`open-y-subprojects/ynorth_gxp_spots_proxy`](https://github.com/open-y-subprojects/ynorth_gxp_spots_proxy) - Availability Spots Cache Proxy for Groupex PRO embed API Syncer into PEF — **Deprecated.** GroupEx Pro API is no longer available.
 1. [`open-y-subprojects/openy_node_alert`](https://github.com/open-y-subprojects/openy_node_alert) - Alerts APP for YMCA Website Services
 1. [`open-y-subprojects/openy_focal_point`](https://github.com/open-y-subprojects/openy_focal_point) - YMCA Website Services Focal Point routines
 1. [`open-y-subprojects/shared_content_server`](https://github.com/open-y-subprojects/shared_content_server) - Shared Content Server
 1. [`ynorth-projects/openy_node_session`](https://github.com/ynorth-projects/openy_node_session) - YMCA Website Services Node Session
 1. [`drupal/openy_repeat`](https://www.drupal.org/project/openy_repeat) - Repeat API for PEF. Schedules APP built in Vue.js (moved to drupal.org)
-1. [`ynorth-projects/openy_pef_gxp_sync`](https://github.com/ynorth-projects/openy_pef_gxp_sync) - Groupex Pro Embed/OpenY Syncer into PEF
+1. [`ynorth-projects/openy_pef_gxp_sync`](https://github.com/ynorth-projects/openy_pef_gxp_sync) - Groupex Pro Embed/OpenY Syncer into PEF — **Deprecated.** GroupEx Pro API is no longer available.
 1. [`ymcatwincities/ymca_sync`](https://github.com/ymcatwincities/ymca_sync) - Syncer backend core
 1. [`YCloudYUSA/yusaopeny_activity_finder`](https://github.com/YCloudYUSA/yusaopeny_activity_finder) - Activity Finder app
 1. [`ymcatwincities/media_entity_document`](https://github.com/ymcatwincities/media_entity_document) - Media Entity Document

--- a/content/en/docs/development/Decoupled-(-external-)-projects-of-OpenY/_index.md
+++ b/content/en/docs/development/Decoupled-(-external-)-projects-of-OpenY/_index.md
@@ -16,7 +16,7 @@ Check all GitHub for the tag [``openy-decoupled``](https://github.com/topics/ope
 1. [`YCloudYUSA/yusaopeny_loc_finder`](https://github.com/YCloudYUSA/yusaopeny_loc_filter) - Extended Location Finder
 1. [`Open-Y-subprojects/reqclique_gxp_sync`](https://github.com/Open-Y-subprojects/reqclique_gxp_sync) - Reqclique Group Exercise Sync — **Deprecated.** GroupEx Pro API is no longer available.
 1. [`open-y-subprojects/virtual_y_signaling_server`](https://github.com/open-y-subprojects/virtual_y_signaling_server) - Signalling server for Virtual Y
-1. [`open-y-subprojects/openy_daxko_gxp_syncer`](https://github.com/open-y-subprojects/openy_daxko_gxp_syncer) - Daxko GroupEx PRO v1 API Syncer into Program Event Framework — **Deprecated.** GroupEx Pro API is no longer available.
+1. [`open-y-subprojects/openy_daxko_gxp_syncer`](https://github.com/open-y-subprojects/openy_daxko_gxp_syncer) - Daxko GroupEx PRO v1 API Syncer into Program Event Framework
 1. [`open-y-subprojects/ynorth_gxp_spots_proxy`](https://github.com/open-y-subprojects/ynorth_gxp_spots_proxy) - Availability Spots Cache Proxy for Groupex PRO embed API Syncer into PEF — **Deprecated.** GroupEx Pro API is no longer available.
 1. [`open-y-subprojects/openy_node_alert`](https://github.com/open-y-subprojects/openy_node_alert) - Alerts APP for YMCA Website Services
 1. [`open-y-subprojects/openy_focal_point`](https://github.com/open-y-subprojects/openy_focal_point) - YMCA Website Services Focal Point routines

--- a/content/en/docs/development/GroupEx-PRO-quick-start/_index.md
+++ b/content/en/docs/development/GroupEx-PRO-quick-start/_index.md
@@ -1,7 +1,11 @@
 ---
-title: GroupEx PRO quick start
+title: GroupEx PRO quick start (Deprecated)
 aliases:
   - /docs/wiki/groupex-pro-quick-start/
 ---
+
+{{% alert title="Deprecated" color="warning" %}}
+The GroupEx Pro API is no longer available. As of `groupexpro` 3.0.0, the deprecated modules (`groupex_form_cache`, `openy_group_schedules`, `openy_gxp`) are automatically uninstalled during `drush updb`. No manual action is needed. See [Daxko GroupEx Pro API deprecation](../daxko/#groupex-pro-apis) for details.
+{{% /alert %}}
 
 This document has been moved to [ynorth-projects/openy_pef_gxp_sync](https://github.com/ynorth-projects/openy_pef_gxp_sync#readme).

--- a/content/en/docs/development/Important-versions-for-upgrade-path/_index.md
+++ b/content/en/docs/development/Important-versions-for-upgrade-path/_index.md
@@ -49,6 +49,22 @@ These supplemental documents elaborate on a few specific cases:
   - [Drupal 11 Migration Guide - Prerequisites](../drupal-11-migration/#prerequisites)
   - [Official Drupal.org Upgrade Guide: Drupal 10 to 11](https://www.drupal.org/docs/upgrading-drupal/upgrading-drupal/how-to-upgrade-from-drupal-10-to-drupal-11)
 
+- **`11.1.0.2`** - Required intermediate step before upgrading to 11.3.x. Ensures all pre-11.3 update hooks are executed.
+
+- **`11.3.1.0`** - **Major Drupal 11.3 release**. Drupal core upgraded from 11.1.9 to 11.3.3. Key changes:
+  - **Entity Browser replaced by Media Library** - all media fields migrated from Entity Browser/DropzoneJS to core Media Library
+  - **Google Analytics module removed** - replaced by Google Tag (`google_tag`). Sites must configure Google Tag after upgrade
+  - **GroupEx Pro deprecated** - automatically uninstalled via `drush updb`
+  - **Media Directories replaced by Media Tags** (`media_directories` removed)
+  - **Trash module enabled by default** - provides soft-delete functionality for content
+  - **AVIF GD extension required** - PHP must have GD compiled with AVIF support
+  - **History module removed** from Drupal core
+  - **Removed modules:** `entity_browser`, `dropzonejs`, `google_analytics`, `media_directories`, `history`, `groupex_pro`
+  - **67% faster installation**
+  - PHP 8.4/8.5 stability fixes
+
+  **⚠️ Upgrade path requirement:** You must upgrade to **11.1.0.2** first before upgrading to 11.3.1.0. Do not skip directly from 11.1.0.0 to 11.3.x.
+
 ---
 See [Version Constraints practices for YMCA Website Services]({{< relref "Composer-version-constraints-for-Open-Y" >}})
 
@@ -69,7 +85,12 @@ See the [Drupal 11 Migration Guide](../drupal-11-migration/) for:
 - Known issues (jQuery 3.x compatibility)
 - Upgrade steps and troubleshooting
 
-**Note:** Drupal 11 stable release **11.1.0.0** is now available (as of November 18, 2025) and is production-ready. All major components including Activity Finder and Memberships are Drupal 11-compatible. See the [11.1.0.0 Release Notes]({{< relref "/blog/releases/release-ds-11.1.0.0" >}}) and [Full Changelog](../drupal-11-changelog/) for complete details.
+### For 11.3.x Upgrades
+
+- **AVIF support required:** Ensure your PHP GD extension is compiled with AVIF support before upgrading to 11.3.1.0.
+- **Entity Browser removal:** All Entity Browser and DropzoneJS widgets are automatically migrated to Media Library. Review your custom media fields after upgrade.
+- **Google Analytics replacement:** The `google_analytics` module is removed. Configure `google_tag` module after upgrade to maintain tracking.
+- **GroupEx Pro:** Automatically uninstalled during `drush updb`. If your site uses GroupEx Pro integrations, plan for alternative solutions before upgrading.
 
 
 If you are faced with an issue when `composer` installs an improper version of `drupal/core` for the chosen version of YMCA Website Services from the list above, please use this trick in order to downgrade:

--- a/content/en/docs/development/Open-Y-3rd-party-dependencies/_index.md
+++ b/content/en/docs/development/Open-Y-3rd-party-dependencies/_index.md
@@ -8,8 +8,8 @@ YMCA Website Services's system requirements generally track [those of Drupal](ht
 
 ## Current Version Requirements (Drupal 11)
 
-- **Drupal**: 11.1.x or higher
-- **PHP**: 8.3 or higher
+- **Drupal**: 11.3.x or higher
+- **PHP**: 8.3 or higher (8.4 and 8.5 tested for stability)
 - **Composer**: 2.0 or higher
 - **Database**: MySQL 8.0+ OR MariaDB 10.6+
 - **Web Server**: Apache 2.4+ OR Nginx 1.18+

--- a/content/en/docs/development/Open-Y-Release-Schedule-and-Guidelines/_index.md
+++ b/content/en/docs/development/Open-Y-Release-Schedule-and-Guidelines/_index.md
@@ -32,9 +32,9 @@ Major releases bring YMCA Website Services up to compatibility with new Drupal c
 - PHP version requirement updates
 
 **Recent major releases:**
+- **11.3.1.0** (March 2026) - Drupal 11.3.3 core, Entity Browser replaced by Media Library, Google Analytics replaced by Google Tag, GroupEx Pro deprecated
 - **11.1.0.0** (November 18, 2025) - First stable Drupal 11 release with full production readiness
 - **10.5.0.1** (July 14, 2025) - Latest Drupal 10 stable release
-- **10.4.0.0** (June 17, 2024) - Drupal 10.4 core initialization
 
 #### Minor Releases
 
@@ -69,7 +69,6 @@ YMCA Website Services releases are coordinated with [Drupal core's release sched
 
 #### Upcoming Drupal Core Milestones
 
-- **Drupal 11.3.0 / 10.6.0:** December 8, 2025
 - **Drupal 10 End of Life:** December 9, 2026
 - **Drupal 12:** Expected 2026
 
@@ -85,7 +84,7 @@ View all releases and release notes:
 **Latest stable release:** Check [GitHub Releases](https://github.com/YCloudYUSA/yusaopeny/releases) for the most current version.
 
 **Supported versions:**
-- Drupal 11.x: **11.1.0.0** (stable release as of November 18, 2025) - [Release Notes]({{< relref "/blog/releases/release-ds-11.1.0.0" >}}) | [Full Changelog]({{< relref "/docs/development/drupal-11-changelog" >}})
+- Drupal 11.x: **11.3.1.0** (latest stable release, Drupal core 11.3.3)
 - Drupal 10.x: **10.5.0.1** (supported until December 2026)
 
 ### Virtual Y Releases

--- a/content/en/docs/development/Open-Y-Smoke-Tests-Index/_index.md
+++ b/content/en/docs/development/Open-Y-Smoke-Tests-Index/_index.md
@@ -18,5 +18,5 @@ aliases:
 - [Banner](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_banner/SMOKE_TESTS.md)
 - [Simple Content](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_simple_content/SMOKE_TESTS.md)
 - [Grid Content](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_grid_content/SMOKE_TESTS.md)
-- [Embedded GroupEx Pro Schedule](https://git.drupalcode.org/project/groupexpro/-/blob/main/modules/embedded_groupexpro_schedule/SMOKE_TESTS.md)
+- ~~[Embedded GroupEx Pro Schedule](https://git.drupalcode.org/project/groupexpro/-/blob/main/modules/embedded_groupexpro_schedule/SMOKE_TESTS.md)~~ — **Deprecated.** GroupEx Pro API is no longer available.
 - [YMCA Website Services Search](https://github.com/YCloudYUSA/yusaopeny/blob/9.x-2.x/modules/custom/openy_search/SMOKE_TESTS.md)

--- a/content/en/docs/development/Open-Y-Smoke-Tests-Index/_index.md
+++ b/content/en/docs/development/Open-Y-Smoke-Tests-Index/_index.md
@@ -18,5 +18,5 @@ aliases:
 - [Banner](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_banner/SMOKE_TESTS.md)
 - [Simple Content](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_simple_content/SMOKE_TESTS.md)
 - [Grid Content](https://github.com/open-y-subprojects/openy_features/blob/main/openy_prgf/modules/openy_prgf_grid_content/SMOKE_TESTS.md)
-- ~~[Embedded GroupEx Pro Schedule](https://git.drupalcode.org/project/groupexpro/-/blob/main/modules/embedded_groupexpro_schedule/SMOKE_TESTS.md)~~ — **Deprecated.** GroupEx Pro API is no longer available.
+- [Embedded GroupEx Pro Schedule](https://git.drupalcode.org/project/groupexpro/-/blob/main/modules/embedded_groupexpro_schedule/SMOKE_TESTS.md)
 - [YMCA Website Services Search](https://github.com/YCloudYUSA/yusaopeny/blob/9.x-2.x/modules/custom/openy_search/SMOKE_TESTS.md)

--- a/content/en/docs/development/OpenY-upgrade-how-to-for-Developers/_index.md
+++ b/content/en/docs/development/OpenY-upgrade-how-to-for-Developers/_index.md
@@ -28,8 +28,8 @@ Ensure you have a working computer or virtual machine with:
 - Ubuntu 20.04 (16.04, 18.04, or any decent Ubuntu LTS version) 64 bit
 - MySQL 5.7+ (8+ is preferred because of the performance improvements)
 - Apache 2.4 (or Nginx + php-fpm in case if you are fine with htaccess issues down the road)
-- PHP 8.1 (pre 8.1 could be an issue with some contrib modules)
-- Drush 12 || 10 || 11
+- PHP 8.3+ (required for Drupal 11; PHP 8.4/8.5 supported as of 11.3.1.0)
+- Drush 13 || 12
 
 **Recommended development environment**: [DDEV](https://ddev.com/) (Docker-based development environment)
 
@@ -123,9 +123,9 @@ Use [`drush sql-dump`](https://www.drush.org/latest/commands/sql_dump/) or anoth
 For major version upgrades between Drupal core versions, refer to these dedicated guides:
 
 - **[Drupal 9 to Drupal 10](../drupal-10-update/)** - Detailed guide for upgrading from Drupal 9.x to Drupal 10.x
-- **[Drupal 10 to Drupal 11](../drupal-11-migration/)** - Beta release guide for early adopters (stable Q4 2025)
+- **[Drupal 10 to Drupal 11](../drupal-11-migration/)** - Migration guide for upgrading to Drupal 11
 
-**Note:** Most YMCAs should remain on Drupal 10 until the stable Drupal 11 release in Q4 2025. Drupal 10 is supported until December 9, 2026.
+**Note:** Drupal 11 stable releases are available (11.1.0.0+). The latest release is 11.3.1.0, which includes Drupal core 11.3.3. See [Important Versions for Upgrade Path](../important-versions-for-upgrade-path/) for the required upgrade sequence.
 
 ---
 

--- a/content/en/docs/development/Server Requirements/_index.md
+++ b/content/en/docs/development/Server Requirements/_index.md
@@ -8,8 +8,8 @@ If you need to prepare server for the YMCA Website Services instance, here below
 
 ### For Drupal 11 (Current Version)
 
-- **Drupal**: 11.1.x or higher
-- **PHP**: 8.3 or higher
+- **Drupal**: 11.3.x (as of YMCA Website Services 11.3.1.0)
+- **PHP**: 8.3 or higher (8.4 and 8.5 supported)
 - **Composer**: 2.0 or higher
 - **Database**:
   - MySQL 8.0+ OR
@@ -29,7 +29,7 @@ For detailed requirements, see the [official Drupal system requirements](https:/
   - php8.3-curl
   - php8.3-dev
   - php8.3-fpm (for Nginx)
-  - php8.3-gd
+  - php8.3-gd (**must include AVIF support** - required as of 11.3.1.0)
   - php8.3-mysql
   - php8.3-xml
   - php8.3-mbstring
@@ -54,11 +54,12 @@ For detailed requirements, see the [official Drupal system requirements](https:/
 
 ## Version-Specific Requirements
 
-### Drupal 11 (Beta)
+### Drupal 11 (Stable)
 
-- **PHP**: 8.3 or higher
+- **PHP**: 8.3 or higher (8.4 and 8.5 supported)
 - **MySQL**: 8.0+ or MariaDB 10.6+
-- See [Drupal 11 Migration Guide](../drupal-11-migration/) (Beta - stable Q4 2025)
+- **GD with AVIF support** required as of 11.3.1.0
+- See [Drupal 11 Migration Guide](../drupal-11-migration/)
 
 ### Drupal 10
 

--- a/content/en/docs/development/daxko/_index.md
+++ b/content/en/docs/development/daxko/_index.md
@@ -10,6 +10,10 @@ Account configuration must be setup before the Program Registration paragraph wi
 
 ## GroupEx Pro
 
+{{% alert title="Deprecation Notice" color="warning" %}}
+GroupEx Pro integration modules have been deprecated and removed from the YMCA Website Services distribution as of version 11.3.1.0. Sites still using GroupEx Pro should migrate to alternative schedule solutions.
+{{% /alert %}}
+
 There are three methods of integrating GroupEx Pro with your YMCA Website Services site. In order from most to least  complex/customizable:
 
 - API integration

--- a/content/en/docs/development/drupal-10-update/_index.md
+++ b/content/en/docs/development/drupal-10-update/_index.md
@@ -144,15 +144,14 @@ Breaking down the error message:
 
 ## Planning for Drupal 11
 
-After successfully upgrading to Drupal 10, you may want to plan for Drupal 11 in the future.
+After successfully upgrading to Drupal 10, you should plan your upgrade to Drupal 11. The latest stable release is **11.3.1.0** (Drupal core 11.3.3).
 
 See the [Drupal 11 Migration Guide](../drupal-11-migration/) for:
-- Drupal 11 beta status and Q4 2025 stable release timeline
 - New features and breaking changes in Drupal 11
 - Known issues (including jQuery 3.x compatibility)
 - Prerequisites and upgrade steps
 
-**Note:** Most YMCAs should remain on Drupal 10 until the stable Drupal 11 release in Q4 2025. Drupal 10 is supported until December 9, 2026.
+**Note:** Drupal 10 is supported until December 9, 2026, but upgrading to Drupal 11 is recommended.
 
 ---
 

--- a/content/en/docs/development/drupal-11-changelog/_index.md
+++ b/content/en/docs/development/drupal-11-changelog/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "[DRAFT] Drupal 11 Full Changelog (11.1.0.0)"
-description: Comprehensive feature and package changes from YMCA Website Services 10.5.0.1 to 11.1.0.0
+title: "Drupal 11 Full Changelog"
+description: Comprehensive feature and package changes for YMCA Website Services Drupal 11 releases
 aliases:
   - /docs/development/drupal-11-full-changelog/
 tags:
@@ -11,11 +11,28 @@ weight: 10
 ---
 
 
+**Latest Release**: [11.3.1.0](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0) (March 2026)
+
+See the [11.3.1.0 release notes on GitHub](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0) for the full changelog of the latest release, including:
+- Drupal core 11.1.9 → 11.3.3
+- Entity Browser replaced by Media Library
+- Google Analytics module removed (replaced by Google Tag)
+- GroupEx Pro deprecated and auto-uninstalled
+- Media Tags vocabulary replacing media_directories
+- Trash module enabled by default
+- 17 LB block packages with major version bumps
+- AVIF GD extension required
+- 67% faster installation, 93% less memory usage
+
+---
+
+## 10.5.0.1 to 11.1.0.0 Changelog
+
 **Generated**: 2025-11-19 05:38:01
 
 **Repository**: git@github.com:YCloudYUSA/yusaopeny.git
 **Comparing**:
-- 10.5.0.1 (Jul 14, 2025)- 11.1.0.0 (Nov 17, 2025)
+- 10.5.0.1 (Jul 14, 2025) → 11.1.0.0 (Nov 17, 2025)
 
 
 ---

--- a/content/en/docs/development/drupal-11-migration/_index.md
+++ b/content/en/docs/development/drupal-11-migration/_index.md
@@ -10,78 +10,121 @@ tags:
 
 ## Overview
 
-**YMCA Website Services 11.1.0.0** is the first **stable release** with Drupal 11 compatibility, released November 18, 2025. This release brings modern architecture, improved performance, and enhanced capabilities for YMCA organizations.
+**YMCA Website Services 11.3.1.0** is the latest stable release, bringing Drupal core 11.3.3, major performance improvements, and significant architectural changes. The first Drupal 11 release was 11.1.0.0 (November 18, 2025).
 
 All major components including Activity Finder 6.0.0 and Memberships 3.1.0 have full Drupal 11 support, making this release production-ready.
 
-### What's New in Drupal 11
+### What's New in 11.3.1.0
 
-From the [11.1.0.0 stable release](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.1.0.0):
+From the [11.3.1.0 release](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0):
 
 **Major Platform Upgrades:**
-- Drupal 11 core upgrade
-- PHP 8.3+ requirement (Symfony 7 integration)
-- Composer-only module management (module upload UI removed)
+- Drupal core 11.1.9 → 11.3.3
+- Entity Browser replaced by Media Library for all media fields
+- Google Analytics module removed, replaced by Google Tag
+- Trash module (`drupal/trash`) enabled by default
+- Media Tags new vocabulary replacing `media_directories`
+- Y Styles expanded to Landing Page, Event, Article, Reusable blocks
+- Global table styles for CKEditor content
+- 67% faster installation, 93% less memory usage
+- PHP 8.4/8.5 deprecation fixes (256K messages/day eliminated)
+- Breadcrumb cache fix (removed max-age=0)
+- AVIF GD extension now required
 
-**New Development Features:**
-- Single Directory Components (SDC) for streamlined UI component development
-- Object-Oriented Hooks (class-based hooks replacing procedural)
-- New Icon Management API
-- Native WebP image support
+**Removed/Deprecated in 11.3.1.0:**
+- `google_analytics` module (replaced by `google_tag`)
+- `entity_browser`, `dropzonejs_eb_widget`, `entity_browser_entity_form` (replaced by Media Library)
+- GroupEx Pro deprecated (`groupex_form_cache`, `openy_group_schedules`, `openy_gxp` auto-uninstalled)
+- `history` module removed
+- `doctrine/annotations` and `psr/cache` removed
 
-**Content Editor Improvements:**
-- Project Browser for visual module installation
-- Workspaces module for content staging
-- Experimental new admin navigation system
-
-**Removed/Deprecated:**
+**Previously Removed in 11.1.0.0:**
 - `ckeditor` (replaced by CKEditor 5)
 - `ckeditor5_font` module
 - `inline_entity_menu_form` module
 - `bartik` and `seven` themes
 - `panelbutton` module
 
+**Major Package Version Bumps:**
+- 17 Layout Builder block packages received major version bumps (e.g., `lb_cards` 2.2.1→3.0.0, `lb_hero` 1.5.4→2.0.2)
+- 5 theme packages updated (e.g., `ws_colorway_canada` 1.3.2→2.0.1, `ws_event` 1.5.7→2.0.1)
+- 6 content type packages updated (e.g., `y_camp` 2.1.0→3.0.0, `y_lb_article` 1.3.4→2.0.1)
+- Core infrastructure: `field_group` 3.6.0→4.0.0, `openy_features` 4.2.0→5.0.5, `y_lb` 4.0.6→5.0.4
+
 For complete release details, see:
-- **[11.1.0.0 Release Notes]({{< relref "/blog/releases/release-ds-11.1.0.0" >}})**
 - **[Full Drupal 11 Changelog]({{< relref "/docs/development/drupal-11-changelog" >}})** - Comprehensive feature and package changes
+- **[11.3.1.0 on GitHub](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0)**
 - **[11.1.0.0 on GitHub](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.1.0.0)**
 
 ---
 
 ## Before You Upgrade
 
-**Production Ready:** Version 11.1.0.0 is a **stable release** suitable for production use. However:
+**Production Ready:** Version 11.3.1.0 is the latest **stable release** suitable for production use. However:
 
 - **Always test first:** Upgrade staging/testing environments before production
 - **Create backups:** Ensure you have complete backups before upgrading
 - **Review changes:** See the [Full Changelog]({{< relref "/docs/development/drupal-11-changelog" >}}) for detailed changes
 - **Plan accordingly:** Major version upgrades require planning and testing
+- **AVIF support required:** Ensure the GD extension has AVIF support enabled on your server
 
 ---
 
-## ⚠️ Critical: Google Analytics Module Deprecation
+## Critical: Upgrade Path Requirement
 
-**IMPORTANT:** The `google_analytics` module is deprecated and will not be available in Drupal 11.2+. You must migrate to `google_tag` module before upgrading past Drupal 11.1.
+**IMPORTANT:** You must upgrade to **11.1.0.2** first before upgrading to 11.3.x. Direct upgrades from 10.x to 11.3 are not supported.
+
+### Required Upgrade Sequence
+
+1. Upgrade to **11.1.0.2** from your current Drupal 10 version
+2. Run database updates (`drush updb --no-cache-clear -y && drush cr`)
+3. Verify site stability on 11.1.0.2
+4. Then upgrade to **11.3.1.0**
+5. Run database updates again
+
+---
+
+## Critical: Google Analytics Module Removed
+
+**IMPORTANT:** As of 11.3.1.0, the `google_analytics` module has been **removed** and replaced by `google_tag`. If you are upgrading from a version that uses `google_analytics`, you must migrate before or during the upgrade to 11.3.
 
 ### Why This Matters
 
-- The `google_analytics` module is being removed from Drupal core
-- The `google_tag` module will remain available and is the recommended replacement
-- Drupal 11.1 is the last version where migration path from `google_analytics` to `google_tag` is supported
+- The `google_analytics` module has been removed from the distribution
+- The `google_tag` module is the replacement
+- 11.1.x is the last version where both modules coexist, providing a migration path
 
 ### If You Skip This Step
 
-If you upgrade directly to Drupal 11.2 or later without migrating:
-- ❌ The `google_analytics` module will not be available
-- ❌ Your existing Google Analytics configuration will be lost
-- ❌ You'll need to manually reconfigure tracking via `google_tag`
+If you upgrade directly to 11.3 without migrating:
+- Your existing Google Analytics configuration will be lost
+- You will need to manually reconfigure tracking via `google_tag`
 
-### Upgrade Sequence
+### Recommended Approach
 
-1. ✅ Update directly to Drupal 11.1
-2. ✅ Migrate from `google_analytics` to `google_tag` module
-3. ✅ Verify analytics tracking is working
-4. ✅ Only then proceed to newer point releases (11.2+)
+1. Upgrade to 11.1.0.2 first
+2. Migrate from `google_analytics` to `google_tag` module
+3. Verify analytics tracking is working
+4. Then proceed to 11.3.1.0
+
+---
+
+## Critical: Entity Browser Replaced by Media Library
+
+As of 11.3.1.0, **Entity Browser** has been fully replaced by **Media Library** for all media fields. The packages `dropzonejs_eb_widget`, `entity_browser_entity_form`, and `entity_browser` have been removed.
+
+This migration happens automatically via database updates, but you should verify that all media fields function correctly after upgrading.
+
+---
+
+## GroupEx Pro Deprecated
+
+The following GroupEx Pro modules are **auto-uninstalled** in 11.3.1.0:
+- `groupex_form_cache`
+- `openy_group_schedules`
+- `openy_gxp`
+
+If your site relies on GroupEx Pro scheduling, plan a migration to an alternative before upgrading.
 
 ---
 
@@ -91,12 +134,14 @@ Before upgrading to Drupal 11:
 
 1. **Update to latest Drupal 10:** Ensure you're on Drupal 10.3.x or higher
 2. **Upgrade PHP:** Update server to PHP 8.3 or higher
-3. **Backup everything:** Database, files, and code
-4. **Test on staging:** Never upgrade production directly
+3. **Enable AVIF in GD:** The GD extension must have AVIF support (required for 11.3+)
+4. **Backup everything:** Database, files, and code
+5. **Test on staging:** Never upgrade production directly
+6. **Plan for module removals:** Review the Entity Browser, Google Analytics, and GroupEx Pro sections above
 
 ---
 
-## Upgrade Process for Drupal 11.1+
+## Upgrade Process for Drupal 11.x
 
 ### Critical: Database Update Command Order
 
@@ -175,3 +220,4 @@ drush cr
 - [Server Requirements](../server-requirements/)
 - [Upgrade Guide for Developers](../openy-upgrade-how-to-for-developers/)
 - [YMCA Website Services Releases](https://github.com/YCloudYUSA/yusaopeny/releases)
+- [11.3.1.0 Release](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0)

--- a/content/en/docs/development/program-event-framework/_index.md
+++ b/content/en/docs/development/program-event-framework/_index.md
@@ -24,8 +24,8 @@ These provide integrations to pull content from external systems into the conten
 - [Simple Daxko Integration (deprecated) (`drupal/daxko`)](https://www.drupal.org/project/daxko)
 - [ActiveNet Integration (`drupal/activenet`)](https://www.drupal.org/project/activenet)
 - [Personify Integration (`drupal/personify`)](https://www.drupal.org/project/personify)
-- [GroupEx Pro (Daxko) Integration (`drupal/groupexpro`)](https://www.drupal.org/project/groupexpro)
-- [PEF (Program Event Framework) GXP (GroupEx Pro) Sync (`ynorth-projects/openy_pef_gxp_sync`)](https://github.com/ynorth-projects/openy_pef_gxp_sync)
+- [GroupEx Pro (Daxko) Integration (`drupal/groupexpro`)](https://www.drupal.org/project/groupexpro) — **Deprecated.** The GroupEx Pro API is no longer available. As of `groupexpro` 3.0.0, deprecated modules are automatically uninstalled during `drush updb`.
+- [PEF (Program Event Framework) GXP (GroupEx Pro) Sync (`ynorth-projects/openy_pef_gxp_sync`)](https://github.com/ynorth-projects/openy_pef_gxp_sync) — **Deprecated.** See above.
 - [YMCA 360 (Y360) Integration (`drupal/yusaopeny_ymca360`)](https://www.drupal.org/project/yusaopeny_ymca360)
 - [Traction Rec Integration (`ycloudyusa/openy_traction_rec`)](https://github.com/YCloudYUSA/openy_traction_rec)
   - [How to configure the Traction Rec integration](https://github.com/YCloudYUSA/openy_traction_rec?tab=readme-ov-file#ymca-website-services-traction-rec-integration)

--- a/content/en/docs/glossary/_index.md
+++ b/content/en/docs/glossary/_index.md
@@ -43,7 +43,7 @@ Five Jars
 : A partner agency that works on the distribution and provides services directly to YMCAs. Also "5J". [Five Jars](https://fivejars.com/).
 
 GroupEx Pro
-: A group-exercise management platform. Integrates with the Group Schedules feature. Acquired by Daxko in 2019. [GroupEx PRO](https://groupexpro.com/).
+: **[Deprecated]** A group-exercise management platform formerly integrated with the Group Schedules feature. Acquired by Daxko in 2019. The GroupEx Pro API is no longer available; as of `groupexpro` 3.0.0, deprecated modules are automatically uninstalled during `drush updb`. [GroupEx PRO](https://groupexpro.com/).
 
 ImageX
 : A partner agency that works on the distribution and provides services directly to YMCAs. Also "ImageX Media". [ImageX](https://imagexmedia.com/).

--- a/content/en/docs/howto/_index.md
+++ b/content/en/docs/howto/_index.md
@@ -118,7 +118,7 @@ Browse our collection of step-by-step guides to accomplish common tasks with YMC
             <span class="badge bg-warning text-dark" style="font-size: 0.7rem;">INTERMEDIATE</span>
           </div>
           <h5 class="card-title mb-2" style="font-size: 1rem; font-weight: 600;">Track & Analyze Users</h5>
-          <p class="card-text text-muted" style="font-size: 0.875rem; line-height: 1.4;">Set up Google Analytics and monitoring for user insights.</p>
+          <p class="card-text text-muted" style="font-size: 0.875rem; line-height: 1.4;">Set up Google Tag and monitoring for user insights.</p>
         </div>
       </div>
     </a>

--- a/content/en/docs/howto/migrate-to-lb/_index.md
+++ b/content/en/docs/howto/migrate-to-lb/_index.md
@@ -100,7 +100,7 @@ Date Block
 : None
 
 Embedded GroupEx Pro Schedule
-: GroupEx Pro integration has been deprecated. We recommend moving to a [Code](../../user-documentation/layout-builder/code) block for any third-party schedule embeds.
+: Due to changes in the GroupEx Pro embed functionality, we recommend moving to a [Code](../../user-documentation/layout-builder/code) block.
 
 FAQ
 : [Accordion](../../user-documentation/layout-builder/accordion)

--- a/content/en/docs/howto/migrate-to-lb/_index.md
+++ b/content/en/docs/howto/migrate-to-lb/_index.md
@@ -100,7 +100,7 @@ Date Block
 : None
 
 Embedded GroupEx Pro Schedule
-: Due to changes in the GroupEx Pro embed functionality, we recommend moving to a [Code](../../user-documentation/layout-builder/code) block.
+: GroupEx Pro integration has been deprecated. We recommend moving to a [Code](../../user-documentation/layout-builder/code) block for any third-party schedule embeds.
 
 FAQ
 : [Accordion](../../user-documentation/layout-builder/accordion)

--- a/content/en/docs/howto/set-up-lb/_index.md
+++ b/content/en/docs/howto/set-up-lb/_index.md
@@ -96,11 +96,11 @@ This list contains the relevant permissions for using Layout Builder in the YMCA
   - Or, give permissions to only specific block types:
     - **{Block type}: {View/Edit/Delete/Revert} content block**
 - Add other necessary permissions for managing content:
-  - **Entity Browser**
-    - **Access Media Directories: Field widget pages**
-    - **Access Media Directories: Standalone pages**
-  - **Media Directories UI**
-    - **Access to Media Directories browser**
+  - **Media Library**
+    - **View media** (to browse existing media)
+    - **Create media** (to upload new media)
+  - **Media Tags**
+    - **Access to Media Tags browser**
   - **Contextual Links**
     - **Use Contextual Links**
 - **Node** - These permissions allow users to create, edit, delete, or revert the Layout Builder _content types_.

--- a/content/en/docs/howto/track-users/_index.md
+++ b/content/en/docs/howto/track-users/_index.md
@@ -9,24 +9,24 @@ aliases:
 
 ## Google Analytics
 
-YMCA Website Services uses the Drupal contrib [Google Analytics module](https://www.drupal.org/project/google_analytics) to enable [Google Analytics](https://marketingplatform.google.com/about/analytics/) tracking on your YMCA Website Services site.
+YMCA Website Services uses the Drupal contrib [Google Tag module](https://www.drupal.org/project/google_tag) to enable [Google Analytics](https://marketingplatform.google.com/about/analytics/) tracking on your YMCA Website Services site.
 
-To get started, you should first create a GA property. Use the [Analytics Help](https://support.google.com/analytics/#topic=10737980) for assistance.
+To get started, you should first create a GA4 property. Use the [Analytics Help](https://support.google.com/analytics/#topic=10737980) for assistance.
 
 ### Configuration
 
-Configuration is done at the standard module configuration page: `/admin/config/services/google-analytics`.
+Configuration is done at the Google Tag configuration page: `/admin/config/services/google_tag`. Add your GA4 measurement ID (beginning with `G-`) to connect your site to Google Analytics.
 
-### Google Analytics Version Compatibility
+### Migration from google_analytics Module
 
-In the [9.2.11](https://github.com/YCloudYUSA/yusaopeny/releases/tag/9.2.11) release in November 2021, YMCA Website Services [added support for Google Analytics 4](https://github.com/YCloudYUSA/yusaopeny/pull/2400). If your site has been updated to YMCA Website Services 9.2.11 or greater AND the `google_analytics` module has been updated to 4.x you should be able to use GA4. Otherwise you'll need to stick with GA3.
+As of YMCA Website Services 11.3, the `google_analytics` module has been removed and replaced by the `google_tag` module. The `google_tag` module is installed automatically during the upgrade, and the `google_analytics` module is removed. You will need to configure your GA4 measurement ID at `/admin/config/services/google_tag` after upgrading.
 
 ## Search Tracking with Google Analytics
 
 ### Prerequisites
 
 - Google Analytics account to track you site should be created.
-- Google Analytics contrib module should be enabled and configured to use existing GA account.
+- Google Tag contrib module should be enabled and configured to use existing GA account.
 
 ### Steps
 

--- a/content/en/docs/site-builder/getting-started/_index.md
+++ b/content/en/docs/site-builder/getting-started/_index.md
@@ -69,7 +69,7 @@ Before installing, decide which solution fits your YMCA best.
 
 Before starting, ensure your server meets these requirements:
 
-- **Drupal:** 11.1.x or higher
+- **Drupal:** 11.3.x or higher
 - **PHP:** 8.3 or higher
 - **Database:** MySQL 8.0+ or MariaDB 10.6+
 - **Web Server:** Apache 2.4+ or Nginx 1.18+

--- a/content/en/docs/small-y/vs-full-distribution.md
+++ b/content/en/docs/small-y/vs-full-distribution.md
@@ -64,7 +64,7 @@ Both Small Y and Full Distribution include these core features:
 - ✅ **Group Schedules** - Class schedule displays
 - ✅ **Webforms** - Contact forms, surveys, registrations
 - ✅ **SEO Tools** - Meta tags, XML sitemap, redirects
-- ✅ **Google Analytics** - Traffic tracking
+- ✅ **Google Tag** - Traffic tracking via Google Analytics (GA4)
 - ✅ **Security Updates** - Monthly Drupal core and module updates
 
 ### Small Y Template Includes
@@ -129,7 +129,7 @@ You can enable any of these Full Distribution modules via **Extend** → **Modul
 
 ❌ **Different installation presets** - Once installed, you can't switch from Small Y preset to Full preset without reinstalling
 ❌ **Demo content after installation** - Demo content is only available during initial installation
-❌ **Past Drupal versions** - Small Y requires Drupal 11.1+
+❌ **Past Drupal versions** - Small Y requires Drupal 11.3+
 
 ---
 
@@ -138,7 +138,7 @@ You can enable any of these Full Distribution modules via **Extend** → **Modul
 ### System Requirements
 
 Both Small Y and Full Distribution require:
-- **Drupal:** 11.1.x or higher
+- **Drupal:** 11.3.x or higher
 - **PHP:** 8.3 or higher
 - **Database:** MySQL 8.0+ or MariaDB 10.6+
 - **Web Server:** Apache 2.4+ or Nginx 1.18+

--- a/content/en/docs/troubleshooting/performance/_index.md
+++ b/content/en/docs/troubleshooting/performance/_index.md
@@ -58,7 +58,7 @@ Having performance problems? This guide will help you diagnose and optimize your
    ```
 
 2. **Optimize Images**
-   - Use WebP format where possible
+   - Use WebP or AVIF format where possible (AVIF requires the GD extension with AVIF support)
    - Enable image optimization: `/admin/config/media/image-styles`
 
 3. **Clean Up Database**

--- a/content/en/docs/troubleshooting/upgrades/_index.md
+++ b/content/en/docs/troubleshooting/upgrades/_index.md
@@ -23,7 +23,7 @@ Encountering problems during an upgrade? Find solutions to common upgrade issues
 
 2. **Follow Official Upgrade Path**
    - Drupal 9 → 10: [Upgrade Guide](/docs/development/drupal-10-update/)
-   - Drupal 10 → 11: [Migration Guide](/docs/development/drupal-11-migration/) (Beta - stable Q4 2025)
+   - Drupal 10 → 11: [Migration Guide](/docs/development/drupal-11-migration/)
 
 3. **Use Upgrade Status Module**
    ```bash

--- a/content/en/docs/user-documentation/content-editing-basics/_index.md
+++ b/content/en/docs/user-documentation/content-editing-basics/_index.md
@@ -119,7 +119,7 @@ Some link fields contain an additional **Attributes** section. You can add attri
 
 ### Image Fields/Image Library
 
-You can add, edit and upload images any time you see a tab with Image in the title. To use the media browser, click the button in the image field.
+You can add, edit and upload images any time you see a tab with Image in the title. To use the Media Library, click the **Add media** button in the image field.
 
 [More on Using the Image Library ⇒](../text-editor/adding-images)
 

--- a/content/en/docs/user-documentation/content-types/blog-post/_index.md
+++ b/content/en/docs/user-documentation/content-types/blog-post/_index.md
@@ -94,7 +94,7 @@ When choosing color card, you are presented with two styling options in dropdown
 
 The content area is the main body of your page. You can use the default fields entered below for a simple block post or build a more robust layout using paragraphs.
 
-* **Image**: Displays above your description and inside a Photo Card. Not required. Uses the [media browser and image field.](../../media)
+* **Image**: Displays above your description and inside a Photo Card. Not required. Uses the [Media Library and image field.](../../media)
 
 * **Description**: [Using the text editor](../../text-editor), you can enter anything from a brief summary to the entire body of your text.
 

--- a/content/en/docs/user-documentation/content-types/lb-landing-page/_index.md
+++ b/content/en/docs/user-documentation/content-types/lb-landing-page/_index.md
@@ -510,7 +510,7 @@ Right (40%):
 - **Social proof:** Testimonials vs. stats vs. logos
 
 **Simple tests (no tools required):**
-1. Change headline on homepage, track bounce rate + time on site (Google Analytics)
+1. Change headline on homepage, track bounce rate + time on site (Google Tag)
 2. Test CTA button text, measure clicks (heatmap tools like Hotjar)
 3. Try different hero images, monitor conversions
 
@@ -527,7 +527,7 @@ One organization changed just three words in their CTA and saw **104% conversion
 **Tools to understand user behavior:**
 - **Hotjar** - Heatmaps, session recordings, surveys (free tier available)
 - **Microsoft Clarity** - Free heatmaps and session recordings
-- **Google Analytics** - Behavior flow, exit pages, conversion funnels
+- **Google Tag / GA4** - Behavior flow, exit pages, conversion funnels
 
 **What to look for:**
 - **Heatmaps:** Where do users click? Are they finding CTAs?

--- a/content/en/docs/user-documentation/content-types/news-post/_index.md
+++ b/content/en/docs/user-documentation/content-types/news-post/_index.md
@@ -61,7 +61,7 @@ There are three fields that appear above the accordion tabs below:
 
 The content area is the main body of your page. You can use the default fields entered below for a simple block post or build a more robust layout using paragraphs.
 
-* **Image**: Displays above your description and inside a News Post listing. Not required. Uses the [media browser and image field.](../../media)
+* **Image**: Displays above your description and inside a News Post listing. Not required. Uses the [Media Library and image field.](../../media)
 
 * **Description**: [Using the text editor](../../text-editor), you can enter anything from a brief summary to the entire body of your text.
 

--- a/content/en/docs/user-documentation/content-types/program-subcategory/_index.md
+++ b/content/en/docs/user-documentation/content-types/program-subcategory/_index.md
@@ -35,7 +35,7 @@ The Program tag will pull your Program Subcategory in as a horizontal card on a 
 
 ### Header Area
 
-* **Image**: Using an image field, select an image from the media browser. Displays in the header and as a thumbnail in [Categories Listing](../../paragraphs/categories-listing).
+* **Image**: Using an image field, select an image from the Media Library. Displays in the header and as a thumbnail in [Categories Listing](../../paragraphs/categories-listing).
 
 * **Color**: A dropdown to select a background color for your header.
 

--- a/content/en/docs/user-documentation/layout-builder/advanced-options/_index.md
+++ b/content/en/docs/user-documentation/layout-builder/advanced-options/_index.md
@@ -10,7 +10,7 @@ A huge amount of configuration is available with Layout Builder components using
 
 ## Y Styles
 
-These options provide customizations of Layout Builder-enabled pages at the Content Type, Page, and Component(/Block) level.
+These options provide customizations of Layout Builder-enabled pages at the Content Type, Page, and Component(/Block) level. As of the 11.3.1.0 release, Y Styles support has been expanded to additional content types beyond Landing Pages.
 
 Styles inherit from content types, to pages, to components. Some styles can also be overridden at each level - block styles can override page styles, which can override content type styles.
 

--- a/content/en/docs/user-documentation/layout-builder/breadcrumbs/_index.md
+++ b/content/en/docs/user-documentation/layout-builder/breadcrumbs/_index.md
@@ -36,3 +36,7 @@ Fill in the content fields:
 {{% alert color=warning title=Note: %}}
 The Breadcrumbs block may not show the correct path while editing the page layout, but it will display properly for viewers.
 {{% /alert %}}
+
+## Caching
+
+As of the 11.3.1.0 release, breadcrumb caching has been improved. Previously, breadcrumbs were set with `max-age=0`, which prevented them from being cached and could negatively impact page performance. This has been fixed so that breadcrumbs are now properly cached along with the rest of the page.

--- a/content/en/docs/user-documentation/layout-builder/table/_index.md
+++ b/content/en/docs/user-documentation/layout-builder/table/_index.md
@@ -30,5 +30,6 @@ Fill in the content fields:
 - **Body**: A full text editor to add tables or other content to the page.
   - To add a table in the editor, click the **Table** icon, then configure the table options in the popup. ![A screenshot of the table icon and properties popup.](lb_table_icon.png)
   - To edit an existing table properties, right click in the table and then choose an option from the menu. ![A screenshot of the table operations menu.](lb_table_menu.png)
+  - As of the 11.3.1.0 release, global table styles are applied automatically to tables created in CKEditor, providing consistent styling across all Layout Builder content types.
 
 {{< readfile "../lb-save-block.partial" >}}

--- a/content/en/docs/user-documentation/media/_index.md
+++ b/content/en/docs/user-documentation/media/_index.md
@@ -2,18 +2,16 @@
 title: "Images and Documents"
 weight: 6
 description: >
-  The media library stores images and files, allowing you to have custom cropping, focal pointing, folders and image styles.
+  The media library stores images and files, allowing you to have custom cropping, focal pointing, tags, and image styles.
 ---
 
 ## Video tutorials
 
 Learn more about media management in the distribution. Some of these videos use older versions of the distribution.
 
-- [Using Media Directories](https://www.youtube.com/watch?v=gcaBlhyPZEY)
 - [Embedding Images onto a Web Page](https://www.youtube.com/watch?v=xogdtPEYxgg)
 - [Tagging your images](https://www.youtube.com/watch?v=mr6HA7KvXK0)
 - [Replacing Images](https://www.youtube.com/watch?v=5xWzAwww740)
-- [Using the Media Folder](https://www.youtube.com/watch?v=4IC2h1hASF4)
 - [Embedding Videos in the WYSIWYG](https://www.youtube.com/watch?v=nC414txq3F8)
 - [Embedding Documents on a Web Page](https://www.youtube.com/watch?v=5w-_bpHtTLI)
 
@@ -21,9 +19,7 @@ Learn more about media management in the distribution. Some of these videos use 
 
 Your YMCA website has the ability to upload media (images, documents, videos) in bulk (since [9.2.12 - December 2022](https://github.com/YCloudYUSA/yusaopeny/releases/tag/9.2.12)). 
 
-You can batch/bulk upload from **Admin** > **Content** > **Media** (`/admin/content/media`) or **Media Browser** (`/admin/content/browser`). After uploading media, it will be available from the Media list and browser in any component on your site.
-
-#### From the Media list
+You can batch/bulk upload from **Admin** > **Content** > **Media** (`/admin/content/media`). After uploading media, it will be available from the Media Library in any component on your site.
 
 ![The "Upload media in bulk" button](media--bulk-upload.png)
 
@@ -31,13 +27,4 @@ You can batch/bulk upload from **Admin** > **Content** > **Media** (`/admin/cont
 - Click **Upload media in bulk**
 - Choose your media type
 - Drag or choose the media to upload
-- Fill in the required fields in the resulting form.
-
-#### From the Media browser
-
-![The media browser upload dialog with an arrow point to the "Upload files" button and the description "Drop multiple files on this button"](media--bulk-upload-browser.png)
-
-- **Admin** > **Content** > **Media Browser** (`/admin/content/browser`)
-- Click **Add media**
-- Choose your media type in the sidebar, then use the **Choose Files** button to choose or drop files.
 - Fill in the required fields in the resulting form.

--- a/content/en/docs/user-documentation/paragraphs/embedded-gxp-schedule/_index.md
+++ b/content/en/docs/user-documentation/paragraphs/embedded-gxp-schedule/_index.md
@@ -1,11 +1,7 @@
 ---
-title: Embedded GroupEx Pro Schedule (Deprecated)
+title: Embedded GroupEx Pro Schedule
 description: Embed the out-of-box GroupEx Pro schedule script on a page with a single click.
 ---
-
-{{% alert title="Deprecated" color="warning" %}}
-The GroupEx Pro API is no longer available. As of `groupexpro` 3.0.0, the deprecated modules (`groupex_form_cache`, `openy_group_schedules`, `openy_gxp`) are automatically uninstalled during `drush updb`. No manual action is needed. Consider using [Repeat Schedules](../../schedules/group-schedules) or [Activity Finder](../../schedules/activity-finder) as alternatives.
-{{% /alert %}}
 
 ## Example
 

--- a/content/en/docs/user-documentation/paragraphs/embedded-gxp-schedule/_index.md
+++ b/content/en/docs/user-documentation/paragraphs/embedded-gxp-schedule/_index.md
@@ -1,7 +1,11 @@
 ---
-title: Embedded GroupEx Pro Schedule
+title: Embedded GroupEx Pro Schedule (Deprecated)
 description: Embed the out-of-box GroupEx Pro schedule script on a page with a single click.
 ---
+
+{{% alert title="Deprecated" color="warning" %}}
+The GroupEx Pro API is no longer available. As of `groupexpro` 3.0.0, the deprecated modules (`groupex_form_cache`, `openy_group_schedules`, `openy_gxp`) are automatically uninstalled during `drush updb`. No manual action is needed. Consider using [Repeat Schedules](../../schedules/group-schedules) or [Activity Finder](../../schedules/activity-finder) as alternatives.
+{{% /alert %}}
 
 ## Example
 

--- a/content/en/docs/user-documentation/taxonomy/_index.md
+++ b/content/en/docs/user-documentation/taxonomy/_index.md
@@ -5,7 +5,7 @@ description: >
   Group pieces of related content together for tagging, filtering, sorting and grouping.
 ---
 
-The Taxonomy feature in YMCA Website Services creates organized lists of categories, which allow you to group content, create folders for Images ([in YMCA Website Services 2.4 and later](https://github.com/ymcatwincities/openy/releases/tag/8.2.4.0)) and create standard options for dropdown fields in your content.
+The Taxonomy feature in YMCA Website Services creates organized lists of categories, which allow you to group content, tag media items, and create standard options for dropdown fields in your content.
 
 {{< youtube upFz4WrJ1-Q >}}
 
@@ -59,12 +59,7 @@ As mentioned above, Color is a list of colors you can use across your site, prim
 ### Blog/News Category
 These taxonomies tag blog/news posts. Categories display in the sidebar and as filters in your [Blog Post Listing](../content-types/blog-post) and [News Posts Listing](../content-types/news-post) paragraphs, respectively.
 
-### Media Folders
-Creates folders for your images in the media browser.
-
-[View Media Folders tutorial ⇒](https://youtu.be/gcaBlhyPZEY)
-
 ### Media Tags
-Creates tags for filtering images (YMCA Website Services 2.3.3 and earlier), Documents and Videos in the media browser.
+Creates tags for filtering and organizing Images, Documents, and Videos in the Media Library.
 
 [View Image and Document tutorials](../media)

--- a/content/en/docs/user-documentation/text-editor/building-tables/_index.md
+++ b/content/en/docs/user-documentation/text-editor/building-tables/_index.md
@@ -8,6 +8,8 @@ weight: 1
 
 The table editor has been drastically improved in CKEditor 5 and is described in detail [in their documentation](https://ckeditor.com/docs/ckeditor5/latest/features/tables/tables.html).
 
+As of the 11.3.1.0 release, global table styles are applied automatically to tables created in CKEditor across all Layout Builder content types, providing consistent and responsive table presentation without additional configuration.
+
 ### Adding a New Table
 To add a table, click on the table icon. A popup will appear with your initial setup options:
 

--- a/content/en/docs/user-documentation/trash/_index.md
+++ b/content/en/docs/user-documentation/trash/_index.md
@@ -9,6 +9,8 @@ The Trash module provides a safety net for content management by implementing so
 
 ## What is the Trash Module?
 
+As of the 11.3.1.0 release, the Trash module is enabled by default on new YMCA Website Services installations.
+
 The Trash module adds a trash bin for content entities in your YMCA Website Services site. When editors delete content, it isn't immediately removed from the database. Instead, it's moved to a trash storage area where it remains until either:
 
 - An administrator permanently deletes (purges) it

--- a/content/en/docs/user-documentation/virtual-ymca/faq/_index.md
+++ b/content/en/docs/user-documentation/virtual-ymca/faq/_index.md
@@ -83,7 +83,7 @@ For even more Virtual Y FAQs, [check out Y-USA’s post.](https://ds.ymca.org/fr
   * Virtual Y supports the most recent versions of all modern web browsers such as [Edge](https://www.microsoft.com/en-us/windows/microsoft-edge), [Firefox](http://www.mozilla.com/firefox/upgrade.html), [Chrome](http://www.google.com/chrome), [Safari](http://www.apple.com/safari/), and [Opera](http://www.opera.com/)
   * Internet Explorer 11 and earlier are not supported due to the inability of that browser to play videos from services such as [https://youtube.com](https://youtube.com/). Here is [YouTube’s official statement](https://support.google.com/youtube/answer/175292?hl=en) on not supporting Internet Explorer.
 * [User Activity Logs Documentation](../logging)
-* [Setting up Google Analytics for Virtual Y ](https://ycloud.y.org/sites/virtual.y.org/files/2020-08/Virtual-Y-8-Google-Analytics.pdf)(web)
+* [Setting up Google Analytics for Virtual Y ](https://ycloud.y.org/sites/virtual.y.org/files/2020-08/Virtual-Y-8-Google-Analytics.pdf)(web) - **Note:** As of version 11.3.1.0, the `google_analytics` module has been replaced by `google_tag`. Configure tracking at **Admin** > **Configuration** > **Services** > **Google Tag** (`/admin/config/services/google_tag`).
 
 ### Committed to VY - Content Editors
 

--- a/content/en/docs/user-documentation/virtual-ymca/go-live/_index.md
+++ b/content/en/docs/user-documentation/virtual-ymca/go-live/_index.md
@@ -19,6 +19,6 @@ Here are some things you should check before you go live with your Virtual Y sit
   * If you’re using the Daxko Barcode provider, ensure you’ve set the **Message for login failures** at **Virtual Y** > **Virtual YMCA Settings** > **GC Auth Settings** > **Edit Daxko barcode provider**.
 
 ## Final clean-up
-* If you’re using it, ensure you’ve set up Google Analytics at **Configuration** > **System** > **Google Analytics**.
+* If you’re using it, ensure you’ve set up Google Tag at **Configuration** > **Services** > **Google Tag** (`/admin/config/services/google_tag`) with your GA4 measurement ID.
 * If you’re using any basic authentication to protect the site before it goes live (what Y Cloud calls “Site Lock”), ask your hosting partner to turn it off.
 * If you'd like to share content with other Ys, review [Shared Content](../shared-content/) and initiate a connection to the Open Y Shared Content server


### PR DESCRIPTION
## Summary

Updates 41 documentation files to reflect changes from the [YMCA Website Services 11.3.1.0 release](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.0).

### Key documentation changes

- **Entity Browser → Media Library**: Updated all references to reflect that Entity Browser has been replaced by Media Library for all media fields. The "Open media browser" button is now "Add media"
- **Google Analytics → Google Tag**: Updated all references from `google_analytics` module to `google_tag`. Updated configuration paths to `/admin/config/services/google_tag`
- **GroupEx Pro deprecated**: Added deprecation notices to GroupEx Pro docs, schedule docs, and glossary
- **Media Tags**: Updated taxonomy docs to reflect `media_directories` replaced by `media_tags`
- **Trash module**: Added notes about trash module being enabled by default
- **Drupal 11 migration guide**: Major rewrite to cover 11.3.1.0 upgrade path, including the requirement to go through 11.1.0.2 first
- **Important versions**: Added 11.1.0.2 and 11.3.1.0 as critical upgrade path versions
- **Server requirements**: Added AVIF GD extension requirement
- **Changelog**: Updated title, added 11.3.1.0 summary with link to full release notes
- **Performance docs**: Added breadcrumb cache fix note
- **Y Styles**: Updated references to reflect expanded scope (Landing Page, Event, Article, Reusable blocks)

### Files changed

<details>
<summary>41 files modified (click to expand)</summary>

| Category | Files |
|----------|-------|
| **Core upgrade docs** | drupal-11-migration, drupal-11-changelog, Important-versions, Server Requirements, drupal-10-update |
| **Developer docs** | OpenY-upgrade-how-to, GroupEx-PRO, daxko, program-event-framework, 3rd-party-dependencies, Release-Schedule, Smoke-Tests, Decoupled-projects |
| **User docs** | media, taxonomy, content-editing-basics, trash, building-tables, table (LB) |
| **Content types** | lb-landing-page, blog-post, news-post, program-subcategory |
| **Layout Builder** | advanced-options, breadcrumbs |
| **How-to guides** | track-users, set-up-lb, migrate-to-lb, howto index |
| **Getting started** | site-builder, developer, decision-maker |
| **Troubleshooting** | upgrades, performance |
| **Other** | glossary, small-y, virtual-ymca/faq, virtual-ymca/go-live, Group Schedules paragraph, Media Tags taxonomy, embedded-gxp-schedule |

</details>

### Files reviewed but not changed

The remaining ~340 files (blog posts, monthly calls, historical releases, paragraph docs, content-structure references) were reviewed and determined to not require updates based on the 11.3.1.0 changelog.

## Test plan

- [ ] Run `hugo server` locally and verify no broken links or build errors
- [ ] Review Netlify deploy preview for rendering issues
- [ ] Spot-check key pages: drupal-11-migration, track-users, media, taxonomy
- [ ] Verify internal links using `{{< relref >}}` resolve correctly