### PR TITLE
Add release notes structure guide

### DIFF
--- a/content/en/docs/contribution-guidelines/release-notes-guide/_index.md
+++ b/content/en/docs/contribution-guidelines/release-notes-guide/_index.md
@@ -1,13 +1,12 @@
 ---
 title: "Release Notes Structure Guide"
+linkTitle: "Release Notes Guide"
 description: "Best practices for writing multi-audience release notes based on industry research"
 ---
 
-## Release Notes Structure — Research & Recommendations
-
 Research into how leading open source projects handle multi-audience release notes, comparing approaches and identifying best practices.
 
-### How Leading Projects Do It
+## How Leading Projects Do It
 
 | Project | Approach | Persona handling |
 |---------|----------|-----------------|
@@ -19,21 +18,21 @@ Research into how leading open source projects handle multi-audience release not
 
 **Key pattern**: none of these projects create separate files per persona per release. They all use **one document** where sections progressively become more technical.
 
-### Current Approach (PR #149) vs Industry Practice
+## Separate Files vs Sections Within One Document
 
-PR #149 introduces **4 separate persona-specific files** (`content-editor/`, `developer/`, `site-builder/`, `decision-maker/`) per release. This is a new pattern for the project.
+Creating separate per-persona files for each release (e.g., `content-editor/release-X.md`, `developer/release-X.md`, `site-builder/release-X.md`, `decision-maker/release-X.md`) has clear strengths:
 
-**Strengths of separate files:**
 - Each audience sees only what's relevant to them
 - Targeted language per persona
 - Quantified metrics (67% faster, 93% less memory) — excellent communication
 
-**Concerns with separate files:**
-- **Duplication**: The same facts (trash module, media tags, entity browser migration) are repeated across 5 files with different wording. Fixing an error means finding and updating it in multiple places.
-- **Maintenance scale**: Every future release needs 5 coordinated documents. After 5 releases = 25 files to maintain.
+However, it introduces maintenance concerns:
+
+- **Duplication**: The same facts are repeated across multiple files with different wording. Fixing an error means finding and updating it in multiple places.
+- **Maintenance scale**: Every future release needs multiple coordinated documents.
 - **No precedent**: None of the major projects researched (Next.js, Laravel, Stripe, GitLab, Drupal core) use separate files per persona per release.
 
-### Recommended Structure
+## Recommended Structure
 
 A structure that achieves persona targeting without duplication:
 
@@ -68,9 +67,9 @@ A structure that achieves persona targeting without duplication:
 - **Maintainable** — one file to review, one file to fix errors in
 - **Scales naturally** — adding a new release = one new file, not five
 
-### Alternative: YAML Data + Hugo Templates
+## Alternative: YAML Data + Hugo Templates
 
-Since yusaopeny_docs uses Hugo, a more advanced zero-duplication approach:
+Since this documentation site uses Hugo, a more advanced zero-duplication approach is possible:
 
 1. Store release facts in a data file (e.g., `data/releases/v11.3.1.0.yaml`)
 2. Create Hugo templates that render persona-specific pages from the same data
@@ -78,7 +77,7 @@ Since yusaopeny_docs uses Hugo, a more advanced zero-duplication approach:
 
 This requires more upfront setup but eliminates duplication entirely.
 
-### Technical Review Requirement
+## Technical Review Requirement
 
 Developer-facing release notes contain API examples and code snippets. These **must be technically verified** before publication:
 
@@ -89,7 +88,7 @@ Developer-facing release notes contain API examples and code snippets. These **m
 
 **Example of why this matters**: Release 11.3.1.0 developer docs referenced `$entity->delete(['force' => TRUE])` for the Trash module — this API does not exist. `EntityInterface::delete()` accepts zero parameters. The correct approach uses `TrashManager::executeInTrashContext()`.
 
-### References
+## References
 
 - [Next.js 16 Release](https://nextjs.org/blog/next-16) — single post, progressive technical detail
 - [Laravel Upgrade Guide](https://laravel.com/docs/11.x/upgrade) — one doc, code examples per change

--- a/content/en/docs/development/How-we-release-OpenY-distribution-from-code-perspective/_index.md
+++ b/content/en/docs/development/How-we-release-OpenY-distribution-from-code-perspective/_index.md
@@ -26,3 +26,7 @@ When tagging a new release of YMCA Website Services, the Lead Architect takes th
 1. Ensure the version of YMCA Website Services is the proper one in site info (`admin/reports/status`).
 1. Publish announcement in #developers YMCA Website Services Slack channel.
 1. Publish announcement in #general YMCA Website Services Slack channel.
+
+### Release Notes Writing Guide
+
+For best practices on structuring release notes for multiple audiences (content editors, developers, site builders, decision makers), see the [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}).

--- a/content/en/docs/development/release-notes-guide.md
+++ b/content/en/docs/development/release-notes-guide.md
@@ -1,0 +1,99 @@
+---
+title: "Release Notes Structure Guide"
+description: "Best practices for writing multi-audience release notes based on industry research"
+---
+
+## Release Notes Structure — Research & Recommendations
+
+Research into how leading open source projects handle multi-audience release notes, comparing approaches and identifying best practices.
+
+### How Leading Projects Do It
+
+| Project | Approach | Persona handling |
+|---------|----------|-----------------|
+| **Next.js** | Blog post + separate upgrade guide | Sections flow from simple headlines → code examples → breaking changes table |
+| **Laravel** | Single docs page with support policy | Code examples per feature + links to full docs |
+| **Stripe** | API changelog with product filters | Product tags + "Breaking?" column — readers filter themselves |
+| **GitLab** | One release post, PMs add sections via MRs | `## For Engineers`, `## For Operators` within one file |
+| **Drupal core** | Per-issue snippets → consolidated by editor | Contributor writes snippet (knows their change best), editor assembles |
+
+**Key pattern**: none of these projects create separate files per persona per release. They all use **one document** where sections progressively become more technical.
+
+### Current Approach (PR #149) vs Industry Practice
+
+PR #149 introduces **4 separate persona-specific files** (`content-editor/`, `developer/`, `site-builder/`, `decision-maker/`) per release. This is a new pattern for the project.
+
+**Strengths of separate files:**
+- Each audience sees only what's relevant to them
+- Targeted language per persona
+- Quantified metrics (67% faster, 93% less memory) — excellent communication
+
+**Concerns with separate files:**
+- **Duplication**: The same facts (trash module, media tags, entity browser migration) are repeated across 5 files with different wording. Fixing an error means finding and updating it in multiple places.
+- **Maintenance scale**: Every future release needs 5 coordinated documents. After 5 releases = 25 files to maintain.
+- **No precedent**: None of the major projects researched (Next.js, Laravel, Stripe, GitLab, Drupal core) use separate files per persona per release.
+
+### Recommended Structure
+
+A structure that achieves persona targeting without duplication:
+
+```
+# Release X.Y.Z (YYYY-MM-DD)
+
+## Summary (2-3 sentences — for everyone)
+
+## What's New (feature highlights with anchor links — executives scan here)
+
+## For Content Editors
+- UI changes, new workflows, what changed in their daily work
+
+## For Site Builders
+- Config changes, Layout Builder updates, upgrade steps
+
+## For Developers
+- Breaking changes table (Was → Now → Migration)
+- Code examples, API changes, removed modules
+
+## Upgrade Instructions (copy-paste ready)
+
+## Bug Fixes
+
+## Full Changelog (link to GitHub release)
+```
+
+**Why this works:**
+- **Single source of truth** — each fact exists once
+- **Persona targeting** — each audience has a clear section to jump to
+- **Shareable** — anchor links let you share direct URLs to each persona section
+- **Maintainable** — one file to review, one file to fix errors in
+- **Scales naturally** — adding a new release = one new file, not five
+
+### Alternative: YAML Data + Hugo Templates
+
+Since yusaopeny_docs uses Hugo, a more advanced zero-duplication approach:
+
+1. Store release facts in a data file (e.g., `data/releases/v11.3.1.0.yaml`)
+2. Create Hugo templates that render persona-specific pages from the same data
+3. Each persona page is auto-generated — zero manual duplication
+
+This requires more upfront setup but eliminates duplication entirely.
+
+### Technical Review Requirement
+
+Developer-facing release notes contain API examples and code snippets. These **must be technically verified** before publication:
+
+- Method signatures must match actual Drupal core and contrib module APIs
+- Service names must exist in the service container
+- Code examples must be runnable (not hypothetical)
+- Breaking changes must reference actual change records
+
+**Example of why this matters**: Release 11.3.1.0 developer docs referenced `$entity->delete(['force' => TRUE])` for the Trash module — this API does not exist. `EntityInterface::delete()` accepts zero parameters. The correct approach uses `TrashManager::executeInTrashContext()`.
+
+### References
+
+- [Next.js 16 Release](https://nextjs.org/blog/next-16) — single post, progressive technical detail
+- [Laravel Upgrade Guide](https://laravel.com/docs/11.x/upgrade) — one doc, code examples per change
+- [Stripe API Changelog](https://docs.stripe.com/changelog) — filterable by product area
+- [GitLab Release Posts Handbook](https://handbook.gitlab.com/handbook/marketing/blog/release-posts/) — one post, PM-contributed sections
+- [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — community standard format
+- [Drupal Core Release Notes Policy](https://www.drupal.org/about/core/policies/maintainers/release-notes)


### PR DESCRIPTION
## Summary
- Adds a release notes structure guide based on research into how Next.js, Laravel, Stripe, GitLab, and Drupal core handle multi-audience release documentation
- Recommends single-document approach with persona sections over separate per-persona files
- Includes technical review requirements for developer-facing content

## Context
Based on review of PR #149, researched industry best practices for release notes that serve multiple audiences (content editors, developers, site builders, decision makers) while maintaining a single source of truth.

## References
- PR #149 review discussion
- ITCR-1123