### PR TITLE
docs: improve discoverability of release process

### DIFF
--- a/content/en/docs/contribution-guidelines/release-notes-guide/_index.md
+++ b/content/en/docs/contribution-guidelines/release-notes-guide/_index.md
@@ -2,7 +2,15 @@
 title: "Release Notes Structure Guide"
 linkTitle: "Release Notes Guide"
 description: "Best practices for writing multi-audience release notes based on industry research"
+keywords:
+  - release-notes
+  - changelog
+  - structure
+  - audiences
+  - writing-guide
 ---
+
+> This guide covers **how to write release notes**. For the **code release process** (tagging, `openy.info.yml` version bumps, mirror refresh, Slack announcements), see [Release Process]({{< relref "/docs/development/How-we-release-OpenY-distribution-from-code-perspective" >}}).
 
 Research into how leading open source projects handle multi-audience release notes, comparing approaches and identifying best practices.
 

--- a/content/en/docs/development/How-we-release-OpenY-distribution-from-code-perspective/_index.md
+++ b/content/en/docs/development/How-we-release-OpenY-distribution-from-code-perspective/_index.md
@@ -1,32 +1,96 @@
 ---
-title: Release processes
+title: Release Process
+linkTitle: Release Process
+description: Step-by-step code release process for YMCA Website Services, including version bumps in info.yml, tagging, and announcements.
+keywords:
+  - release
+  - releasing
+  - tagging
+  - tag
+  - version-bump
+  - info.yml
+  - openy.info.yml
+  - mirror
+  - cibox
+  - slack-announcement
+  - lead-architect
 aliases:
   - /docs/wiki/how-we-release-openy-distribution-from-code-perspective/
 ---
 
-### Repos involved in releases
+> Looking for **how to write release notes** (structure, audiences, formatting)? See the [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}).
+>
+> Looking for **when to release** (cadence, schedule)? See [Release Schedule and Guidelines]({{< relref "/docs/development/Open-Y-Release-Schedule-and-Guidelines" >}}).
 
-1. YMCA Website Services Drupal Profile Distribution [YCloudYUSA/yusaopeny](https://github.com/YCloudYUSA/yusaopeny)
-1. YMCA Website Services Project for initiating an YMCA Website Services instance - [YCloudYUSA/yusaopeny-project](https://github.com/YCloudYUSA/yusaopeny-project)
-1. Continuous Integration/DevOps for rebuilding/installing YMCA Website Services - [YCloudYUSA/yusaopeny-cibox-build](https://github.com/YCloudYUSA/yusaopeny-cibox-build)
+This page documents the code-side release process: what repositories are tagged, where version numbers live, and the announcement workflow.
 
-### Release Management
+## Repos involved in releases
+
+1. YMCA Website Services Drupal Profile Distribution — [YCloudYUSA/yusaopeny](https://github.com/YCloudYUSA/yusaopeny)
+2. YMCA Website Services Project for initiating a YMCA Website Services instance — [YCloudYUSA/yusaopeny-project](https://github.com/YCloudYUSA/yusaopeny-project)
+3. Continuous Integration/DevOps for rebuilding/installing YMCA Website Services — [YCloudYUSA/yusaopeny-cibox-build](https://github.com/YCloudYUSA/yusaopeny-cibox-build)
+
+## Release Management
 
 When tagging a new release of YMCA Website Services, the Lead Architect takes the following steps:
 
-1. Review/Merge/Update [YCloudYUSA/yusaopeny-project](https://github.com/YCloudYUSA/yusaopeny-project) (usually composer.json or/and oneline script install) and tag a new release there.
-1. Review/Merge all Pull Requests in [YCloudYUSA/yusaopeny](https://github.com/YCloudYUSA/yusaopeny) that were planned for release.
-1. Change the YMCA Website Services version in [`openy.info.yml`](https://github.com/YCloudYUSA/yusaopeny/blob/9.x-2.x/openy.info.yml#L5).
-1. Change the YMCA Website Services version in major modules if there were changes to them (Activity Finder, PEF, etc).
-1. Create Changelog release notes as a draft and include Contributors as well as major issues fixed/introduced.
-1. Spin up a copy of an YMCA Website Services site and check top priority functionality for regressions.
-1. Send for review to Core Team, get approval.
-1. Change the YMCA Website Services version to next with -dev suffix for developers in [`openy.info.yml`](https://github.com/YCloudYUSA/yusaopeny/blob/main/openy.info.yml#L5).
-1. Refresh the YMCA Website Services private mirror on the `openy.cibox.tools` CI server.
-1. Ensure the version of YMCA Website Services is the proper one in site info (`admin/reports/status`).
-1. Publish announcement in #developers YMCA Website Services Slack channel.
-1. Publish announcement in #general YMCA Website Services Slack channel.
+### 1. Merge and tag `yusaopeny-project`
 
-### Release Notes Writing Guide
+Review, merge, and update [YCloudYUSA/yusaopeny-project](https://github.com/YCloudYUSA/yusaopeny-project) (usually `composer.json` and/or the one-line install script) and tag a new release there.
 
-For best practices on structuring release notes for multiple audiences (content editors, developers, site builders, decision makers), see the [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}).
+### 2. Merge planned PRs in `yusaopeny`
+
+Review and merge all Pull Requests in [YCloudYUSA/yusaopeny](https://github.com/YCloudYUSA/yusaopeny) that were planned for this release.
+
+### 3. Bump version in `openy.info.yml`
+
+Change the YMCA Website Services version in [`openy.info.yml`](https://github.com/YCloudYUSA/yusaopeny/blob/main/openy.info.yml) (the `version:` field).
+
+```yaml
+# openy.info.yml
+name: YMCA Website Services
+type: profile
+version: 11.3.1.1
+```
+
+This is the canonical version reported in `admin/reports/status` and used by Composer/Drush tooling. The release tag in Git must match this value.
+
+### 4. Bump version in major module info.yml files (if changed)
+
+If major modules changed in this release (Activity Finder, PEF, etc.), bump their `version:` in each module's `*.info.yml` as well.
+
+### 5. Draft Changelog release notes
+
+Create Changelog release notes as a draft. Include contributors and major issues fixed or introduced. For structure and audience guidance, see the [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}).
+
+### 6. Regression check
+
+Spin up a copy of a YMCA Website Services site and check top-priority functionality for regressions.
+
+### 7. Core Team review
+
+Send for review to the Core Team and get approval.
+
+### 8. Bump `openy.info.yml` to next `-dev`
+
+After tagging, change the YMCA Website Services version in [`openy.info.yml`](https://github.com/YCloudYUSA/yusaopeny/blob/main/openy.info.yml) to the next version with a `-dev` suffix for developers (for example, `11.3.1.2-dev`).
+
+### 9. Refresh the private mirror
+
+Refresh the YMCA Website Services private mirror on the `openy.cibox.tools` CI server.
+
+### 10. Verify version in site info
+
+Ensure the version of YMCA Website Services is the proper one in site info (`admin/reports/status`).
+
+### 11. Announce
+
+Publish announcements in:
+- `#developers` YMCA Website Services Slack channel
+- `#general` YMCA Website Services Slack channel
+
+## Related
+
+- [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}) — how to write the notes themselves
+- [Release Schedule and Guidelines]({{< relref "/docs/development/Open-Y-Release-Schedule-and-Guidelines" >}}) — cadence and policy
+- [Secure DevOps for Composer 2 release]({{< relref "/docs/development/Secure-devops-for-composer-2-release" >}}) — Composer security considerations

--- a/content/en/docs/development/Open-Y-Release-Schedule-and-Guidelines/_index.md
+++ b/content/en/docs/development/Open-Y-Release-Schedule-and-Guidelines/_index.md
@@ -1,8 +1,15 @@
 ---
 title: Release Schedule and Guidelines
+keywords:
+  - release-schedule
+  - release-cadence
+  - versioning
+  - semver
 aliases:
   - /docs/wiki/open-y-release-schedule-and-guidelines/
 ---
+
+> Related: [Release Process]({{< relref "/docs/development/How-we-release-OpenY-distribution-from-code-perspective" >}}) (code-side tagging and `openy.info.yml` bumps) · [Release Notes Structure Guide]({{< relref "/docs/contribution-guidelines/release-notes-guide" >}}) (how to write the notes).
 
 ## YMCA Website Services Release Guidelines
 


### PR DESCRIPTION
## Summary

Release-related documentation lives across three pages with no cross-links, and the canonical code release process (info.yml version bumps, tagging, mirror refresh) sits under a long CamelCase URL (`How-we-release-OpenY-distribution-from-code-perspective`) that is easy to miss when grepping or searching for "release". Readers landing on the Release Notes Structure Guide could not tell that a separate code-side process page existed.

## Changes

- **Release Process page** (`docs/development/How-we-release-OpenY-distribution-from-code-perspective`):
  - Restructured the numbered list into named subsections, each with a clear purpose.
  - Promoted the `openy.info.yml` version bump to its own subsection with a YAML example.
  - Added `description` and `keywords` frontmatter (`info.yml`, `tagging`, `version-bump`, `mirror`, `cibox`, `slack-announcement`, etc.) so the page surfaces in search.
  - Added a callout at the top pointing to the Release Notes Structure Guide and the Release Schedule page.
  - Added a `Related` section at the bottom linking to sibling release docs.

- **Release Notes Structure Guide** (`docs/contribution-guidelines/release-notes-guide`):
  - Added a callout at the top linking to the Release Process page for readers who actually need the code release workflow.
  - Added `keywords` frontmatter.

- **Release Schedule and Guidelines** (`docs/development/Open-Y-Release-Schedule-and-Guidelines`):
  - Added a top callout linking to both the Release Process and the Release Notes Structure Guide.
  - Added `keywords` frontmatter.

## URL stability

No URLs change. Existing `aliases:` entries are preserved.

## Test plan

- [ ] `hugo server` renders all three pages without errors
- [ ] Callouts and `relref` links resolve (no broken-link warnings in the Hugo log)
- [ ] Search index picks up the new `keywords` (verify after Algolia re-index on deploy)