### PR TITLE
docs: DS 11.3.1.6 release notes + upgrade-path list

### DIFF
--- a/content/en/blog/releases/release-ds-11.3.1.6.md
+++ b/content/en/blog/releases/release-ds-11.3.1.6.md
@@ -1,0 +1,26 @@
+---
+title: "Digital Services Release 11.3.1.6"
+description: Annotated release notes. Full changelog on [GitHub](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.6)
+date: 2026-07-06
+---
+
+## Updates & New Features
+
+- **Drupal Core constrained to 11.3.x:**
+  `drupal/core` and `drupal/core-composer-scaffold` are now constrained to `>=11.3 <11.4`. Drupal core 11.4 introduces errors in the distribution, so this release pins sites to the 11.3.x line until 11.4+ compatibility is verified. ([PR #376](https://github.com/YCloudYUSA/yusaopeny/pull/376))
+
+---
+
+## Core & Module Updates
+
+- **Drupal Core**
+    - Constrained to `>=11.3 <11.4` — do not upgrade core to 11.4 on this release.
+
+---
+
+## What's Changed
+
+### YCloudYUSA/yusaopeny
+* Constrain drupal/core to <11.4 to avoid 11.4 errors in https://github.com/YCloudYUSA/yusaopeny/pull/376
+
+**Full Changelog**: https://github.com/YCloudYUSA/yusaopeny/compare/11.3.1.5...11.3.1.6

--- a/content/en/docs/development/Important-versions-for-upgrade-path/_index.md
+++ b/content/en/docs/development/Important-versions-for-upgrade-path/_index.md
@@ -65,6 +65,8 @@ These supplemental documents elaborate on a few specific cases:
 
   **⚠️ Upgrade path requirement:** You must upgrade to **11.1.0.2** first before upgrading to 11.3.1.0. Do not skip directly from 11.1.0.0 to 11.3.x.
 
+- **`11.3.1.6`** - Constrains `drupal/core` and `drupal/core-composer-scaffold` to `>=11.3 <11.4`. Drupal core 11.4 introduces errors in the distribution, so this release pins sites to the 11.3.x line. **Do not upgrade Drupal core to 11.4 on this release** — a later release will lift the constraint once 11.4+ compatibility is verified.
+
 ---
 See [Version Constraints practices for YMCA Website Services]({{< relref "Composer-version-constraints-for-Open-Y" >}})
 


### PR DESCRIPTION
Documentation for [Digital Services 11.3.1.6](https://github.com/YCloudYUSA/yusaopeny/releases/tag/11.3.1.6).

- **Release notes**: `content/en/blog/releases/release-ds-11.3.1.6.md`
- **Important versions list**: add `11.3.1.6` entry to `Important-versions-for-upgrade-path`

Change: constrains `drupal/core` + `drupal/core-composer-scaffold` to `>=11.3 <11.4` to avoid errors introduced by Drupal core 11.4 ([yusaopeny #376](https://github.com/YCloudYUSA/yusaopeny/pull/376)).